### PR TITLE
Fix for wrong Docker image tag

### DIFF
--- a/Chapter02/Activity02.01/k8s-pageview-deploy.yaml
+++ b/Chapter02/Activity02.01/k8s-pageview-deploy.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
       - name: k8s-pageview
-        image: packtworkshops/the-kubernetes-workshop:pageview
+        image: packtworkshops/the-kubernetes-workshop:pageview-v2


### PR DESCRIPTION
Change Docker image tag to pageview-v2, which contains the code to fetch the visitor counter from Redis, see code of the image:

https://github.com/PacktWorkshops/Kubernetes-Workshop/blob/master/Chapter01/Activity1.01/pageview-modified/main.go